### PR TITLE
feat: 弾頭面積入力を直径入力に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 .env.development.local
 .env.test.local
 .env.production.local
+.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Ballistic-JS is a Japanese-language web application for ballistic trajectory calculations. It's a client-side application using vanilla JavaScript with HTML5 Canvas for visualization.
+Ballistic-JS is a Japanese-language web application for ballistic trajectory calculations. It's a client-side
+application using vanilla JavaScript with HTML5 Canvas for visualization.
 
 ## Essential Commands
 
@@ -49,7 +50,8 @@ npx jest -t "calculateTrajectory"
 
 ### Core Files
 
-- **ballistics.js**: Browser version of physics calculations - contains all trajectory math, air resistance formulas, and environmental adjustments
+- **ballistics.js**: Browser version of physics calculations - contains all trajectory math, air resistance
+  formulas, and environmental adjustments
 - **ballistics.node.js**: Node.js-compatible version for testing (CommonJS exports)
 - **app.js**: UI logic, Canvas rendering, user interactions, and CSV export functionality
 - **index.html**: Single-page application entry point with all UI elements
@@ -72,7 +74,8 @@ npx jest -t "calculateTrajectory"
    - Wind effects on both horizontal and vertical components
    - Drag coefficient adjustments
 
-4. **UI State Management**: All UI state is managed through vanilla JavaScript DOM manipulation in app.js, with event listeners for input changes triggering recalculation and re-rendering.
+4. **UI State Management**: All UI state is managed through vanilla JavaScript DOM manipulation in app.js,
+   with event listeners for input changes triggering recalculation and re-rendering.
 
 ## Testing Philosophy
 
@@ -84,8 +87,11 @@ Tests are located in `ballistics.test.js` and focus on the physics calculations.
 
 ## Deployment
 
-The application is automatically deployed to GitHub Pages when changes are pushed to the main branch. The deployment workflow is configured in `.github/workflows/deploy.yml`.
+The application is automatically deployed to GitHub Pages when changes are pushed to the main branch.
+The deployment workflow is configured in `.github/workflows/deploy.yml`.
 
 ## Japanese Localization
 
-All user-facing text is in Japanese. When modifying UI elements or adding features, ensure proper Japanese language is used. The README.md contains mathematical formulas in LaTeX format that explain the physics calculations.
+All user-facing text is in Japanese. When modifying UI elements or adding features, ensure proper Japanese
+language is used. The README.md contains mathematical formulas in LaTeX format that explain the physics
+calculations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ballistic-JS is a Japanese-language web application for ballistic trajectory calculations. It's a client-side application using vanilla JavaScript with HTML5 Canvas for visualization.
+
+## Essential Commands
+
+### Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run tests
+npm test
+
+# Run tests in watch mode (for development)
+npm run test:watch
+
+# Run tests with coverage
+npm run test:coverage
+
+# Run all linters
+npm run lint
+
+# Fix markdown linting issues
+npm run lint:md:fix
+
+# Start local development server
+python -m http.server 8000
+# or
+npx http-server
+```
+
+### Testing Single Files
+
+```bash
+# Run specific test file
+npx jest ballistics.test.js
+
+# Run specific test with pattern matching
+npx jest -t "calculateTrajectory"
+```
+
+## Architecture
+
+### Core Files
+
+- **ballistics.js**: Browser version of physics calculations - contains all trajectory math, air resistance formulas, and environmental adjustments
+- **ballistics.node.js**: Node.js-compatible version for testing (CommonJS exports)
+- **app.js**: UI logic, Canvas rendering, user interactions, and CSV export functionality
+- **index.html**: Single-page application entry point with all UI elements
+
+### Key Implementation Details
+
+1. **Dual Module System**: The project maintains two versions of the ballistics module:
+   - `ballistics.js` uses ES6 modules for the browser
+   - `ballistics.node.js` uses CommonJS for Jest testing
+   - When modifying physics calculations, update both files
+
+2. **Canvas Visualization**: The trajectory is rendered on an HTML5 Canvas element with:
+   - Grid system for distance/height reference
+   - Real-time hover information display
+   - Wind direction indicator
+   - Distance markers at 50m, 100m, 150m, 200m, 300m
+
+3. **Environmental Calculations**: The physics engine accounts for:
+   - Air density variations based on temperature, pressure, humidity, and altitude
+   - Wind effects on both horizontal and vertical components
+   - Drag coefficient adjustments
+
+4. **UI State Management**: All UI state is managed through vanilla JavaScript DOM manipulation in app.js, with event listeners for input changes triggering recalculation and re-rendering.
+
+## Testing Philosophy
+
+Tests are located in `ballistics.test.js` and focus on the physics calculations. When adding new features:
+
+- Test edge cases for environmental conditions
+- Verify trajectory calculations at key distances
+- Ensure proper handling of extreme input values
+
+## Deployment
+
+The application is automatically deployed to GitHub Pages when changes are pushed to the main branch. The deployment workflow is configured in `.github/workflows/deploy.yml`.
+
+## Japanese Localization
+
+All user-facing text is in Japanese. When modifying UI elements or adding features, ensure proper Japanese language is used. The README.md contains mathematical formulas in LaTeX format that explain the physics calculations.

--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ function getInputValues() {
         initialHeight: parseFloat(document.getElementById('initialHeight').value),
         mass: parseFloat(document.getElementById('mass').value) / 1000, // Convert grams to kg
         dragCoeff: parseFloat(document.getElementById('dragCoeff').value),
-        area: parseFloat(document.getElementById('area').value) / 1000000, // Convert mm² to m²
+        diameter: parseFloat(document.getElementById('diameter').value) / 1000, // Convert mm to m
         airDensity: airDensity,
         windSpeed: parseFloat(document.getElementById('windSpeed').value),
         windAngle: parseFloat(document.getElementById('windAngle').value)

--- a/ballistics.js
+++ b/ballistics.js
@@ -11,11 +11,14 @@ class BallisticsCalculator {
             initialHeight = 0,
             mass,
             dragCoeff,
-            area,
+            diameter,
             airDensity,
             windSpeed = 0,
             windAngle = 0
         } = params;
+        
+        // Calculate area from diameter (diameter in m, area in m²)
+        const area = Math.PI * Math.pow(diameter / 2, 2);
 
         const angleRad = angle * Math.PI / 180;
         const vx0 = velocity * Math.cos(angleRad);

--- a/ballistics.node.js
+++ b/ballistics.node.js
@@ -11,9 +11,12 @@ class BallisticsCalculator {
             initialHeight = 0,
             mass,
             dragCoeff,
-            area,
+            diameter,
             airDensity
         } = params;
+        
+        // Calculate area from diameter (diameter in m, area in m²)
+        const area = Math.PI * Math.pow(diameter / 2, 2);
 
         const angleRad = angle * Math.PI / 180;
         const vx0 = velocity * Math.cos(angleRad);

--- a/ballistics.test.js
+++ b/ballistics.test.js
@@ -15,7 +15,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 1.6,
         mass: 0.032, // 32g in kg
         dragCoeff: 0.47,
-        area: 0.000235, // 235mm² in m²
+        diameter: 0.0173, // 17.3mm in m
         airDensity: 1.225
       };
 
@@ -37,7 +37,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 2,
         mass: 0.01,
         dragCoeff: 0.47,
-        area: 0.0001,
+        diameter: 0.0113, // 11.3mm in m
         airDensity: 1.225
       };
 
@@ -91,7 +91,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 0,
         mass: 0.01,
         dragCoeff: 0.47,
-        area: 0.0001,
+        diameter: 0.0113, // 11.3mm in m
         airDensity: 1.225
       };
 
@@ -115,7 +115,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 0,
         mass: 0.032,
         dragCoeff: 0.47,
-        area: 0.000235,
+        diameter: 0.0173, // 17.3mm in m
         airDensity: 1.225
       };
 
@@ -139,7 +139,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 0,
         mass: 0.01,
         dragCoeff: 2.0, // Very high drag
-        area: 0.001,
+        diameter: 0.0357, // 35.7mm in m
         airDensity: 1.225
       };
 
@@ -156,7 +156,7 @@ describe('BallisticsCalculator', () => {
         initialHeight: 0,
         mass: 0.01,
         dragCoeff: 0.47,
-        area: 0.0001,
+        diameter: 0.0113, // 11.3mm in m
         airDensity: 1.225
       };
 

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
                     </div>
                     
                     <div class="input-group">
-                        <label for="area">断面積 (平方ミリメートル):</label>
-                        <input type="number" id="area" value="235" step="0.1">
+                        <label for="diameter">弾頭直径 (mm):</label>
+                        <input type="number" id="diameter" value="17.3" step="0.1">
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- 弾頭の断面積入力を直径入力に変更
- 直径から面積を自動計算する機能を追加
- テストケースを直径ベースに更新

## Test plan
- [x] 既存のテストが全て通ることを確認
- [x] 直径から面積への変換計算が正しいことを確認
- [ ] UIで直径入力が正しく動作することを確認
- [ ] 既存の計算結果と同じ結果が得られることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)